### PR TITLE
[main] 매장이미지 사진 데이터 반영

### DIFF
--- a/src/detail/detail.schema.ts
+++ b/src/detail/detail.schema.ts
@@ -54,6 +54,12 @@ export class Detail extends Document {
 
   @Prop({ type: Date, required: true })
   updatedAt: Date;
+
+  @Prop({ type: Array, required: false, default: [] })
+  storeImages: {
+    file_path: string;
+    photoId: ObjectId;
+  }[];
 }
 
 export const DetailSchema = SchemaFactory.createForClass(Detail);

--- a/src/detail/detail.schema.ts
+++ b/src/detail/detail.schema.ts
@@ -49,13 +49,13 @@ export class Detail extends Document {
   @Prop({ type: String, required: false, default: null })
   introduce: string | null;
 
-  @Prop({ type: Array, required: false, default: null })
-  concept: string[] | null;
+  @Prop({ type: Array, required: false, default: () => [] })
+  concept: string[];
 
   @Prop({ type: Date, required: true })
   updatedAt: Date;
 
-  @Prop({ type: Array, required: false, default: [] })
+  @Prop({ type: Array, required: false, default: () => [] })
   storeImages: {
     file_path: string;
     photoId: ObjectId;

--- a/src/dto/detail.dto.ts
+++ b/src/dto/detail.dto.ts
@@ -21,6 +21,10 @@ export interface IDetailData {
   description: string | null;
   concept: string[] | null;
   updatedAt: Date;
+  storeImages: {
+    file_path: string;
+    photoId: ObjectId;
+  }[];
 }
 
 export class DetailDTO implements IDetailData {
@@ -44,6 +48,11 @@ export class DetailDTO implements IDetailData {
   description: string | null;
   concept: string[] | null;
   updatedAt: Date;
+  storeImages: {
+    file_path: string;
+    photoId: ObjectId;
+  }[];
+
   constructor(data: IDetailData) {
     this._id = data._id;
     this.name = data.name;
@@ -58,6 +67,7 @@ export class DetailDTO implements IDetailData {
     this.description = data.description;
     this.concept = data.concept;
     this.updatedAt = data.updatedAt;
+    this.storeImages = data.storeImages;
   }
 }
 

--- a/src/dto/detail.dto.ts
+++ b/src/dto/detail.dto.ts
@@ -19,7 +19,7 @@ export interface IDetailData {
   phoneNumber: string | null;
   coord: { lat: number; lng: number };
   description: string | null;
-  concept: string[] | null;
+  concept: string[];
   updatedAt: Date;
   storeImages: {
     file_path: string;
@@ -46,7 +46,7 @@ export class DetailDTO implements IDetailData {
   phoneNumber: string | null;
   coord: { lat: number; lng: number };
   description: string | null;
-  concept: string[] | null;
+  concept: string[];
   updatedAt: Date;
   storeImages: {
     file_path: string;


### PR DESCRIPTION
### 1. 매장이미지 사진 데이터 반영
1. 반영사항
    - [x] 매장 이미지 cloudFront url 첨부 후 배열내 객체 형태로 저장
      ```typescript
      interface Photo {
        file_path: string // cdn url
        photoId: string // Mongo ObjectId
      }
      type storeImages = Photo[]
      ```
    - [x] 배열 형태의 데이터는 내부에 데이터가 없을때 빈 배열로 응답하기로 변경